### PR TITLE
refactor: log everything if debug mode is on

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -37,6 +37,7 @@ fn colored_target(target: &str) -> String {
 }
 
 pub fn init_logger() -> Result<()> {
+  let debug = var("LB_DEBUG").is_ok();
   fern::Dispatch::new()
     .format(|out, message, record| {
       out.finish(format_args!("[{}] [{}] {} – {}",
@@ -45,8 +46,8 @@ pub fn init_logger() -> Result<()> {
                               colored_target(record.target()),
                               message))
     })
-    .level(if var("LB_DEBUG").is_ok() { LevelFilter::Debug } else { LevelFilter::Info })
-    .filter(|f| f.level() < Level::Info || f.target().starts_with("lalafell"))
+    .level(if debug { LevelFilter::Debug } else { LevelFilter::Info })
+    .filter(|f| debug || f.level() < Level::Info || f.target().starts_with("lalafell"))
     .chain(io::stdout())
     .apply()
     .chain_err(|| "could not set up logger")

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -47,7 +47,7 @@ pub fn init_logger() -> Result<()> {
                               message))
     })
     .level(if debug { LevelFilter::Debug } else { LevelFilter::Info })
-    .filter(|f| debug || f.level() < Level::Info || f.target().starts_with("lalafell"))
+    .filter(move |f| debug || f.level() < Level::Info || f.target().starts_with("lalafell"))
     .chain(io::stdout())
     .apply()
     .chain_err(|| "could not set up logger")


### PR DESCRIPTION
Two cherry-picked commits from `dev`. Need this for better debug.

Show all debug output in debug mode, not just our own.